### PR TITLE
Add a wrapper for the CMSSupport to allow adding binary target only for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,22 +6,25 @@ import PackageDescription
 let package = Package(
     name: "CMSSupport",
     platforms: [
-        .iOS(.v9)
+        .iOS(.v9),
+        .macOS(.v11),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "CMSSupport",
-            targets: ["CMSSupport", "openssl"]),
+            targets: ["CMSEncryption"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        .binaryTarget(name: "openssl",
-                      path: "openssl/build/openssl.xcframework"),
         .binaryTarget(name: "CMSSupport",
                       path: "output/CMSSupport.xcframework"),
+        .target(name: "CMSEncryption",
+                dependencies: [
+                    .target(name: "CMSSupport", condition: .when(platforms: [.iOS]))
+                ])
     ]
 )

--- a/Sources/CMSEncryption/CMSEncryption.swift
+++ b/Sources/CMSEncryption/CMSEncryption.swift
@@ -1,0 +1,19 @@
+// Created 2/20/23
+// swift-tools-version:5.0
+
+import Foundation
+
+#if canImport(CMSSupport)
+import CMSSupport
+#endif
+
+public final class CMSEncryption {
+
+    public static func cmsEncrypt(_ data: Data, identityPath: String) throws -> (data: Data, encrypted: Bool) {
+        #if canImport(CMSSupport)
+        (try CMSSupport.cmsEncrypt(data, identityPath: identityPath), true)
+        #else
+        (data, false)
+        #endif
+    }
+}


### PR DESCRIPTION
This static library is only build for iOS (not macOS) so any library that imports it will fail to run tests or build tools for macOS.

https://bugs.swift.org/browse/SR-15196

Xcode Version 14.3 beta (14E5197f) fixes this issue _but_ if and only if the binary target is conditionally added to a wrapper library. It's kind of a weird work-around but it will allow us to reference this library for encrypting uploads while still using BridgeClient with admin sign-in to build debugging tools, localization tools, integration testing, and building json schemas.
